### PR TITLE
Added the font size for filament name and made more robust OpenSCAD detection on macOS

### DIFF
--- a/FilamentSamples.scad
+++ b/FilamentSamples.scad
@@ -1,7 +1,7 @@
 // Change For Each Card
 BRAND="extrudr";
 COLOR="Metallic Grey";
-TYPE="PolyTerra PLA";
+TYPE="Biofusion";
 TEMP_HOTEND="225";
 TEMP_BED="60";
 
@@ -13,9 +13,9 @@ COLOR_SIZE=5.5;
 // Change only if absolutely necessary
 TEMP_SIZE=4.2;
 // Change only if absolutely necessary
-BRAND_SIZE=3.8;
+BRAND_SIZE=4.2;
 // Change only if absolutely necessary
-TYPE_SIZE=3.8;
+TYPE_SIZE=4.2;
 
 // change not supported right now
 SHOW_FIRSTLAYER_TEMP=0;

--- a/FilamentSamples.scad
+++ b/FilamentSamples.scad
@@ -47,7 +47,7 @@ PLA_NOTCH_X=73.0;
 
 // PETG Notch
 
-//PETG_NOTCH_X=34.0;
+PETG_NOTCH_X=73.0;
 
 // ABS Notch Location
 

--- a/FilamentSamples.scad
+++ b/FilamentSamples.scad
@@ -1,7 +1,7 @@
 // Change For Each Card
 BRAND="extrudr";
 COLOR="Metallic Grey";
-TYPE="Biofusion";
+TYPE="PolyTerra PLA";
 TEMP_HOTEND="225";
 TEMP_BED="60";
 
@@ -13,9 +13,9 @@ COLOR_SIZE=5.5;
 // Change only if absolutely necessary
 TEMP_SIZE=4.2;
 // Change only if absolutely necessary
-BRAND_SIZE=4.2;
+BRAND_SIZE=3.8;
 // Change only if absolutely necessary
-TYPE_SIZE=4.2;
+TYPE_SIZE=3.8;
 
 // change not supported right now
 SHOW_FIRSTLAYER_TEMP=0;
@@ -101,9 +101,6 @@ module CardBody() {
       
     CardCorner(CARD_LENGTH - CARD_CORNER_RADIUS, CARD_HEIGHT - CARD_CORNER_RADIUS, CARD_EDGE_RADIUS);
     CardCorner(CARD_LENGTH - CARD_CORNER_RADIUS, CARD_HEIGHT - CARD_CORNER_RADIUS, CARD_THICKNESS - CARD_EDGE_RADIUS);
-    
-    
-    
   }
 }
 

--- a/gen_samples.py
+++ b/gen_samples.py
@@ -33,6 +33,7 @@ def gen_samples(file=f"{MYDIR}/samples.csv"):
                 noztemp = ['-D', f'TEMP_HOTEND="{l[3]}"']
                 bedtemp = ['-D', f'TEMP_BED="{l[4]}"']
                 # extra parameter
+                font_size = None
                 if len(l) > 5:
                     font_size = ['-D', f'TYPE_SIZE={l[5]}']
                 infile = f'{MYDIR}/FilamentSamples.scad'
@@ -85,7 +86,7 @@ def find_mac_openscad():
 if __name__ == "__main__":
     find_mac_openscad()
 
-    if len(sys.argv) < 1:
+    if len(sys.argv) < 2:
         print("You did not pass any .csv file, using samples.csv")
         gen_samples()
     else:

--- a/gen_samples.py
+++ b/gen_samples.py
@@ -11,7 +11,7 @@ if platform.system() == 'Windows':
 elif platform.system() == 'Linux':
     OPENSCAD = 'openscad'
 else:
-    OPENSCAD = 'openscad' #'/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD'
+    OPENSCAD = '/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD'
 
 MYDIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -50,7 +50,41 @@ def gen_samples(file=f"{MYDIR}/samples.csv"):
                 subprocess.run(args, check=True)
 
 
+def find_mac_openscad():
+    global OPENSCAD
+    # on mac verify we have openscad
+    if platform.system() == 'Darwin':
+        found = False
+        if not os.path.exists(OPENSCAD):
+            print("OpenSCAD is not in default /Applications")
+            if not os.path.exists(os.path.expanduser('~') + OPENSCAD):
+                print("OpenSCAD is not in user's ~/Applications")
+                print("Trying to see if there is an openscad command in your path...")
+                args = ['openscad', '-v']
+                try:
+                    proc = subprocess.run(args, capture_output=True, check=True)
+                    if proc.returncode == 0:
+                        found = True
+                        print("openscad version found in path: ", proc.stderr.decode())
+                        OPENSCAD='openscad'
+                except Exception:
+                    print("Could not find any openscad command in your path... aborting")
+            else:
+                print("OpenSCAD found in user's application folder")
+                OPENSCAD = os.path.expanduser('~') + OPENSCAD
+                found = True
+        else:
+            print("OpenSCAD found in system application folder")
+            found = True
+        if not found:
+            print("Could not find OpenSCAD binary, please makesure that you have the OpenSCAD app in /applications or "
+                  "~/Applications or an 'openscad' command in your path")
+            sys.exit(1)
+
+
 if __name__ == "__main__":
+    find_mac_openscad()
+
     if len(sys.argv) < 1:
         print("You did not pass any .csv file, using samples.csv")
         gen_samples()

--- a/gen_samples.py
+++ b/gen_samples.py
@@ -25,16 +25,29 @@ def gen_samples(file=f"{MYDIR}/samples.csv"):
             if len(l) > 0:
                 print("Processing:", l)
                 filename = "stl/" + "_".join(l) + ".stl"
-                subprocess.run(
-                    [OPENSCAD,
-                    '-o', filename,
-                    '-D', f'BRAND="{l[0]}"',
-                    '-D', f'TYPE="{l[1]}"',
-                    '-D', f'COLOR="{l[2]}"',
-                    '-D', f'TEMP_HOTEND="{l[3]}"',
-                    '-D', f'TEMP_BED="{l[4]}"',
-                    f'{MYDIR}/FilamentSamples.scad',
-                    ], check=True)
+                args = [OPENSCAD]  # process name
+                outfile = ['-o', filename]
+                brand = ['-D', f'BRAND="{l[0]}"']
+                type = ['-D', f'TYPE="{l[1]}"']
+                color = ['-D', f'COLOR="{l[2]}"']
+                noztemp = ['-D', f'TEMP_HOTEND="{l[3]}"']
+                bedtemp = ['-D', f'TEMP_BED="{l[4]}"']
+                # extra parameter
+                if len(l) > 5:
+                    font_size = ['-D', f'TYPE_SIZE={l[5]}']
+                infile = f'{MYDIR}/FilamentSamples.scad'
+                args.extend(outfile)
+                args.extend(brand)
+                args.extend(type)
+                args.extend(color)
+                args.extend(noztemp)
+                args.extend(bedtemp)
+                if font_size:
+                    print("adding optional parameter font_size: " + l[5])
+                    args.extend(font_size)
+                args.append(infile)  # this MUST be last param
+                print("Calling OpenSCAD with params: ", args)
+                subprocess.run(args, check=True)
 
 
 if __name__ == "__main__":

--- a/gen_samples.py
+++ b/gen_samples.py
@@ -27,6 +27,9 @@ def gen_samples(file=f"{MYDIR}/samples.csv"):
                 if l[0].startswith("#"):
                     print("Line is a comment, skipping...")
                     continue
+                if not l[0].strip():
+                    print("Line is empty, skipping...")
+                    continue
                 filename = "stl/" + "_".join(l) + ".stl"
                 args = [OPENSCAD]  # process name
                 outfile = ['-o', filename]

--- a/gen_samples.py
+++ b/gen_samples.py
@@ -4,15 +4,17 @@ import subprocess
 import csv
 import os
 import platform
+import sys
 
 if platform.system() == 'Windows':
     OPENSCAD = 'C:\Program Files\OpenSCAD\openscad.exe'
 elif platform.system() == 'Linux':
-     OPENSCAD = 'openscad'
+    OPENSCAD = 'openscad'
 else:
-    OPENSCAD = '/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD'
+    OPENSCAD = 'openscad' #'/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD'
 
-MYDIR=os.path.dirname(os.path.realpath(__file__))
+MYDIR = os.path.dirname(os.path.realpath(__file__))
+
 
 def gen_samples(file=f"{MYDIR}/samples.csv"):
     os.makedirs(f"{MYDIR}/stl", exist_ok=True)
@@ -20,18 +22,26 @@ def gen_samples(file=f"{MYDIR}/samples.csv"):
         data = csv.reader(f)
 
         for l in data:
-            print("Processing:", l)
-            filename = "stl/" + "_".join(l) + ".stl"
-            subprocess.run(
-                [OPENSCAD,
-                '-o', filename,
-                '-D', f'BRAND="{l[0]}"',
-                '-D', f'TYPE="{l[1]}"',
-                '-D', f'COLOR="{l[2]}"',
-                '-D', f'TEMP_HOTEND="{l[3]}"',
-                '-D', f'TEMP_BED="{l[4]}"',
-                f'{MYDIR}/FilamentSamples.scad',
-                ], check=True)
+            if len(l) > 0:
+                print("Processing:", l)
+                filename = "stl/" + "_".join(l) + ".stl"
+                subprocess.run(
+                    [OPENSCAD,
+                    '-o', filename,
+                    '-D', f'BRAND="{l[0]}"',
+                    '-D', f'TYPE="{l[1]}"',
+                    '-D', f'COLOR="{l[2]}"',
+                    '-D', f'TEMP_HOTEND="{l[3]}"',
+                    '-D', f'TEMP_BED="{l[4]}"',
+                    f'{MYDIR}/FilamentSamples.scad',
+                    ], check=True)
+
 
 if __name__ == "__main__":
-    gen_samples()
+    if len(sys.argv) < 1:
+        print("You did not pass any .csv file, using samples.csv")
+        gen_samples()
+    else:
+        swatch_file = sys.argv[1]
+        print("Using swatch file: " + swatch_file)
+        gen_samples(swatch_file)

--- a/gen_samples.py
+++ b/gen_samples.py
@@ -24,6 +24,9 @@ def gen_samples(file=f"{MYDIR}/samples.csv"):
         for l in data:
             if len(l) > 0:
                 print("Processing:", l)
+                if l[0].startswith("#"):
+                    print("Line is a comment, skipping...")
+                    continue
                 filename = "stl/" + "_".join(l) + ".stl"
                 args = [OPENSCAD]  # process name
                 outfile = ['-o', filename]
@@ -32,10 +35,19 @@ def gen_samples(file=f"{MYDIR}/samples.csv"):
                 color = ['-D', f'COLOR="{l[2]}"']
                 noztemp = ['-D', f'TEMP_HOTEND="{l[3]}"']
                 bedtemp = ['-D', f'TEMP_BED="{l[4]}"']
-                # extra parameter
-                font_size = None
+                # extra parameters
+                brand_font_size = None
+                material_font_size = None
+                color_font_size = None
                 if len(l) > 5:
-                    font_size = ['-D', f'TYPE_SIZE={l[5]}']
+                    print("brand size: " + l[5])
+                    if l[5]:
+                        brand_font_size = ['-D', f'BRAND_SIZE={l[5]}']
+                if len(l) > 6:
+                    if l[6]:
+                        material_font_size = ['-D', f'TYPE_SIZE={l[6]}']
+                if len(l) > 7 and l[7]:
+                    brand_font_size = ['-D', f'COLOR_SIZE={l[7]}']
                 infile = f'{MYDIR}/FilamentSamples.scad'
                 args.extend(outfile)
                 args.extend(brand)
@@ -43,9 +55,15 @@ def gen_samples(file=f"{MYDIR}/samples.csv"):
                 args.extend(color)
                 args.extend(noztemp)
                 args.extend(bedtemp)
-                if font_size:
-                    print("adding optional parameter font_size: " + l[5])
-                    args.extend(font_size)
+                if brand_font_size:
+                    print("adding optional parameter brand_size: " + l[5])
+                    args.extend(brand_font_size)
+                if material_font_size:
+                    print("adding optional parameter type_size: " + l[6])
+                    args.extend(material_font_size)
+                if color_font_size:
+                    print("adding optional parameter color_size: " + l[7])
+                    args.extend(color_font_size)
                 args.append(infile)  # this MUST be last param
                 print("Calling OpenSCAD with params: ", args)
                 subprocess.run(args, check=True)
@@ -67,7 +85,7 @@ def find_mac_openscad():
                     if proc.returncode == 0:
                         found = True
                         print("openscad version found in path: ", proc.stderr.decode())
-                        OPENSCAD='openscad'
+                        OPENSCAD = 'openscad'
                 except Exception:
                     print("Could not find any openscad command in your path... aborting")
             else:
@@ -78,7 +96,7 @@ def find_mac_openscad():
             print("OpenSCAD found in system application folder")
             found = True
         if not found:
-            print("Could not find OpenSCAD binary, please makesure that you have the OpenSCAD app in /applications or "
+            print("Could not find OpenSCAD binary, please make sure that you have the OpenSCAD app in /applications or "
                   "~/Applications or an 'openscad' command in your path")
             sys.exit(1)
 

--- a/swatches.csv
+++ b/swatches.csv
@@ -1,0 +1,5 @@
+PolyMaker,PolyTerra PLA,Cotton White,190-230,25-60,3.8
+PolyMaker,PolyTerra PLA,Army Dark Green,190-230,25-60,3.8
+Creality,Ender PLA,Grey,195-220,25-60
+eSun,PLA+,Brown,210-230,45-60
+

--- a/swatches.csv
+++ b/swatches.csv
@@ -3,7 +3,7 @@
 #  Brand,Material,Color,NozzleTemp,BedTemp,BrandFontSize,MaterialFontSize,ColorFontSize
 # default value (you can leave empty) for font size is 4.2
 
-#Overture,PLA,Black,190-220,25-60
+Overture,PLA,Black,190-220,25-60
 #Overture,PLA Silk,Yellow,200-220,50-60
 #Overture,PLA,Royal Gold,190-220,25-60
 #PolyMaker,PolyTerra PLA,Cotton White,190-230,25-60,,3.8
@@ -14,5 +14,6 @@
 #Amazon Basics,PETG,Transparent,230-250,60-80,3.6
 #Eryone,PLA+,Skin,190-220,55-70
 #FlashForge,PETG Pro,Burnt Titanium,220-240,80
-Sunlu,TPU Silk,Burgundy,210-240,35
+#Sunlu,TPU Silk,Burgundy,210-240,35
+eSun,eABS+HS,Grey,230-270,90-110
  

--- a/swatches.csv
+++ b/swatches.csv
@@ -11,4 +11,8 @@
 #Creality,Ender PLA,Grey,195-220,25-60
 #eSun,PLA+,Brown,210-230,45-60
 #Bambu Labs,PETG Basic,Blue,240-270,65-75
-Amazon Basics,PETG,Transparent,230-250,60-80,3.6
+#Amazon Basics,PETG,Transparent,230-250,60-80,3.6
+#Eryone,PLA+,Skin,190-220,55-70
+#FlashForge,PETG Pro,Burnt Titanium,220-240,80
+Sunlu,TPU Silk,Burgundy,210-240,35
+ 

--- a/swatches.csv
+++ b/swatches.csv
@@ -1,8 +1,14 @@
-Overture,PLA,Black,190-220,25-60
-Overture,PLA Silk,Yellow,200-220,50-60
-Overture,PLA,Royal Gold,190-220,25-60
-PolyMaker,PolyTerra PLA,Cotton White,190-230,25-60,3.8
-PolyMaker,PolyTerra PLA,Army Dark Green,190-230,25-60,3.8
-Creality,Ender PLA,Grey,195-220,25-60
-eSun,PLA+,Brown,210-230,45-60
+# Lines starting with # are ignored
+# the CVS format is the following:
+#  Brand,Material,Color,NozzleTemp,BedTemp,BrandFontSize,MaterialFontSize,ColorFontSize
+# default value (you can leave empty) for font size is 4.2
 
+#Overture,PLA,Black,190-220,25-60
+#Overture,PLA Silk,Yellow,200-220,50-60
+#Overture,PLA,Royal Gold,190-220,25-60
+#PolyMaker,PolyTerra PLA,Cotton White,190-230,25-60,,3.8
+#PolyMaker,PolyTerra PLA,Army Dark Green,190-230,25-60,,3.8
+#Creality,Ender PLA,Grey,195-220,25-60
+#eSun,PLA+,Brown,210-230,45-60
+#Bambu Labs,PETG Basic,Blue,240-270,65-75
+Amazon Basics,PETG,Transparent,230-250,60-80,3.6

--- a/swatches.csv
+++ b/swatches.csv
@@ -1,3 +1,6 @@
+Overture,PLA,Black,190-220,25-60
+Overture,PLA Silk,Yellow,200-220,50-60
+Overture,PLA,Royal Gold,190-220,25-60
 PolyMaker,PolyTerra PLA,Cotton White,190-230,25-60,3.8
 PolyMaker,PolyTerra PLA,Army Dark Green,190-230,25-60,3.8
 Creality,Ender PLA,Grey,195-220,25-60


### PR DESCRIPTION
I added a few checks to try to find the OpenSCAS on macOS if user (like me) does not have it installed in /Applications
Also i added an optional new parameter to the CVS file to specify the font size for filament name, since i was trying to create a swatch for PolyTerra PLA and it was going to clash with the infill part.